### PR TITLE
Upgrade GPU worker image to Torch 2

### DIFF
--- a/build/gpu-worker.dockerfile
+++ b/build/gpu-worker.dockerfile
@@ -1,10 +1,10 @@
 FROM biigle/build-dist AS intermediate
 
-FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
 LABEL maintainer "Martin Zurowietz <martin@cebitec.uni-bielefeld.de>"
 
 # Find versions here: https://launchpad.net/~ondrej/+archive/ubuntu/php
-ARG PHP_VERSION=8.1.14-2+ubuntu18.04.1+deb.sury.org+1
+ARG PHP_VERSION=8.1.20-1+ubuntu20.04.1+deb.sury.org+1
 RUN LC_ALL=C.UTF-8 apt-get update \
     && apt-get install -y --no-install-recommends software-properties-common \
     && add-apt-repository -y ppa:ondrej/php \

--- a/build/gpu-worker.dockerfile
+++ b/build/gpu-worker.dockerfile
@@ -4,7 +4,7 @@ FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
 LABEL maintainer "Martin Zurowietz <martin@cebitec.uni-bielefeld.de>"
 
 # Find versions here: https://launchpad.net/~ondrej/+archive/ubuntu/php
-ARG PHP_VERSION=8.1.20-1+ubuntu20.04.1+deb.sury.org+1
+ARG PHP_VERSION=8.1.21-1+ubuntu20.04.1+deb.sury.org+1
 RUN LC_ALL=C.UTF-8 apt-get update \
     && apt-get install -y --no-install-recommends software-properties-common \
     && add-apt-repository -y ppa:ondrej/php \

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,10 +1,10 @@
-torch==1.13.*
-torchvision==0.14.*
-mmcv-full==1.7.1
+torch==2.0.*
+torchvision==0.15.*
+mmcv==2.0.*
 # Update CUDA Version if necessary.
 # See: https://mmcv.readthedocs.io/en/latest/get_started/installation.html#install-with-pip
--f https://download.openmmlab.com/mmcv/dist/cu116/torch1.13/index.html
-mmdet==2.28.2
+-f https://download.openmmlab.com/mmcv/dist/cu117/torch2.0/index.html
+mmdet==3.1.*
 albumentations
 scikit-learn
 scikit-image


### PR DESCRIPTION
The Torch 1 base image was based on Ubuntu 18.04 which is no longer supported and has no PHP 8.1 packages available any more.