### PR TITLE
Configure memory limit for workers via INI instead of CLI

### DIFF
--- a/build/worker.dockerfile
+++ b/build/worker.dockerfile
@@ -3,6 +3,8 @@ FROM biigle/build-dist AS intermediate
 FROM ghcr.io/biigle/worker:latest
 MAINTAINER Martin Zurowietz <martin@cebitec.uni-bielefeld.de>
 
+RUN echo "memory_limit=1G" > "$PHP_INI_DIR/conf.d/memory_limit.ini"
+
 COPY --from=intermediate /etc/localtime /etc/localtime
 COPY --from=intermediate /etc/timezone /etc/timezone
 COPY --from=intermediate /var/www /var/www

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     volumes_from:
       - app
     init: true
-    command: "php -d memory_limit=1G artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0"
+    command: "php artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0"
 
   scheduler:
     image: biigle/worker-dist
@@ -57,7 +57,7 @@ services:
       - cache
     volumes_from:
       - app
-    command: "/bin/sh -c 'trap exit TERM; while sleep 60 & wait; do php -d memory_limit=1G artisan schedule:run >> /dev/null 2>&1; done'"
+    command: "/bin/sh -c 'trap exit TERM; while sleep 60 & wait; do php artisan schedule:run >> /dev/null 2>&1; done'"
 
   database:
     image: postgres:14-alpine


### PR DESCRIPTION
If the scheduler runs a sub-command, the memory limit option is not passed along. It only works as expected with the INI.