### PR TITLE
Update artisan script

### DIFF
--- a/artisan
+++ b/artisan
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose exec worker php artisan "$@"
+docker compose exec worker php artisan "$@"


### PR DESCRIPTION
Update artisan script to drop the deprecated `docker-compose`  in favour of `docker compose`.