### PR TITLE
Add max-jobs to worker command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     volumes_from:
       - app
     init: true
-    command: "php artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0"
+    command: "php artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0 --max-jobs=100"
 
   scheduler:
     image: biigle/worker-dist


### PR DESCRIPTION
This is done because there could be memory leaks in the jobs and a continuously running worker process could run out of memory. Compose will automatically restart the worker after 100 jobs.