### PR TITLE
Fix biigle/largo setup

### DIFF
--- a/build/build.dockerfile
+++ b/build/build.dockerfile
@@ -54,8 +54,7 @@ RUN COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${GITHUB_OAUTH_TOKEN}\"}}
         biigle/ananas:${ANANAS_VERSION} \
         --prefer-dist --update-no-dev --ignore-platform-reqs
 
-RUN sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Largo\\LargoServiceProvider::class,' config/app.php \
-    && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Geo\\GeoServiceProvider::class,' config/app.php \
+RUN sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Geo\\GeoServiceProvider::class,' config/app.php \
     && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\ColorSort\\ColorSortServiceProvider::class,' config/app.php \
     && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Laserpoints\\LaserpointsServiceProvider::class,' config/app.php \
     && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Ananas\\AnanasServiceProvider::class,' config/app.php

--- a/build/build.dockerfile
+++ b/build/build.dockerfile
@@ -40,19 +40,22 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 # Force Docker to rebuild following steps.
 ARG FORCE_TIMESTAMP
 
+ARG LARGO_VERSION=">=1.0"
 ARG GEO_VERSION=">=1.0"
 ARG COLOR_SORT_VERSION=">=1.0"
 ARG LASERPOINTS_VERSION=">=1.0"
 ARG ANANAS_VERSION=">=1.0"
 RUN COMPOSER_AUTH="{\"github-oauth\":{\"github.com\":\"${GITHUB_OAUTH_TOKEN}\"}}" \
     php -d memory_limit=-1 composer.phar require \
+        biigle/largo:${LARGO_VERSION} \
         biigle/geo:${GEO_VERSION} \
         biigle/color-sort:${COLOR_SORT_VERSION} \
         biigle/laserpoints:${LASERPOINTS_VERSION} \
         biigle/ananas:${ANANAS_VERSION} \
         --prefer-dist --update-no-dev --ignore-platform-reqs
 
-RUN sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Geo\\GeoServiceProvider::class,' config/app.php \
+RUN sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Largo\\LargoServiceProvider::class,' config/app.php \
+    && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Geo\\GeoServiceProvider::class,' config/app.php \
     && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\ColorSort\\ColorSortServiceProvider::class,' config/app.php \
     && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Laserpoints\\LaserpointsServiceProvider::class,' config/app.php \
     && sed -i '/Insert Biigle module service providers/i Biigle\\Modules\\Ananas\\AnanasServiceProvider::class,' config/app.php

--- a/build/build.sh
+++ b/build/build.sh
@@ -11,6 +11,7 @@ VERSION=${1:-latest}
 docker build -f build.dockerfile -t biigle/build-dist \
     --build-arg TIMEZONE=${APP_TIMEZONE} \
     --build-arg GITHUB_OAUTH_TOKEN=${GITHUB_OAUTH_TOKEN} \
+    --build-arg LARGO_VERSION="^2.0" \
     --build-arg GEO_VERSION="^1.7" \
     --build-arg COLOR_SORT_VERSION="^2.0" \
     --build-arg LASERPOINTS_VERSION="^2.0" \


### PR DESCRIPTION
The package requirement is restored (#36). Otherwise the biigle/largo version would be pinned to the version used by biigle/core on build but we don't want that.