### PR TITLE
Update queue worker configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     volumes_from:
       - app
     init: true
-    command: "php artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0 --max-jobs=100"
+    command: "php artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0 --memory=1024"
 
   scheduler:
     image: biigle/worker-dist


### PR DESCRIPTION
The --max-jobs was meant to restart the worker perodically so the used memory is freed. The --memory flag does this better now that it accurately determines the used memory.

See: https://github.com/biigle/core/pull/1201