### PR TITLE
LabelBOT

### DIFF
--- a/build/build.dockerfile
+++ b/build/build.dockerfile
@@ -13,6 +13,9 @@ RUN apk add --no-cache tzdata \
 RUN apk add --no-cache npm nghttp2-dev \
     && npm install apidoc@"^0.17.0" -g
 
+# Download the DINOv2 weights used by LabelBOT.
+RUN curl -o /var/www/public/assets/dinov2_vits14.onnx https://github.com/biigle/core/releases/download/untagged-253cef706f5a548adf14/dinov2_vits14.onnx
+
 ARG GITHUB_OAUTH_TOKEN
 ARG PUSHER_APP_KEY
 # Compile assets. npm is installed above.


### PR DESCRIPTION
This adds the necessary build configuration for LabelBOT.

Also write detailed release notes to explain what this is about and explain the DB index creation process. The index could be presented as optional, as not everybody might have the disk space available. It will speed up LabelBOT a lot, though. Release text:

> This release adds a major new feature: LabelBOT. This feature automatically suggests labels for new annotations based on similar existing annotations. While LabelBOT will work out of the box with this release, it will be much faster with a special database index. This index uses a substantial amount of disk space (_insert estimate from biigle.de here, something like xGB/yM annotations_) and thus is optional. To build the database index you can execute the `php artisan labelbot:create-index` command inside a Docker container. Building the index may take a long time (_again an estimate from biigle.de_) but your BIIGLE instance will be usable in the meantime. You can monitor the progress of the index building with `php artisan labelbot:index-progress`.