### PR TITLE
Add pyworker service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
       # Services should share the cache directory.
       - TORCH_HOME=storage/largo_cache
       # This is required for much faster CPU processing.
-      # See: See also: https://pytorch.org/tutorials/intermediate/torchserve_with_ipex.html
+      # See: https://pytorch.org/tutorials/intermediate/torchserve_with_ipex.html
       - OMP_NUM_THREADS=2
     command: "python resources/scripts/ExtractFeaturesWorker.py"
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,21 @@ services:
     init: true
     command: "php artisan queue:work --queue=high,default --sleep=5 --tries=3 --timeout=0 --memory=1024"
 
+  pyworker:
+    image: ghcr.io/biigle/pyworker
+    user: ${USER_ID}:${GROUP_ID}
+    restart: always
+    volumes_from:
+      - app
+    init: true
+    environment:
+      # Services should share the cache directory.
+      - TORCH_HOME=storage/largo_cache
+      # This is required for much faster CPU processing.
+      # See: See also: https://pytorch.org/tutorials/intermediate/torchserve_with_ipex.html
+      - OMP_NUM_THREADS=2
+    command: "python resources/scripts/ExtractFeaturesWorker.py"
+
   scheduler:
     image: biigle/worker-dist
     user: ${USER_ID}:${GROUP_ID}


### PR DESCRIPTION
This adds a new pyworker service to the Docker Compose file. The pyworker runs a continuous Python process that generates feature vectors for new image and video annotations. This is much faster than the previous method of executing a Python script in the PHP job.

If you expect high load and have scaled the regular PHP worker service to more containers, consider to scale the pyworker service, too. It probably needs a couple fewer containers than the regular worker.

References https://github.com/biigle/core/pull/1352