### PR TITLE
Revert removal of .env file

### DIFF
--- a/build/build.dockerfile
+++ b/build/build.dockerfile
@@ -76,8 +76,8 @@ RUN curl -O https://doctum.long-term.support/releases/latest/doctum.phar \
 COPY config/filesystems.php /var/www/config/filesystems.php
 
 # The .env file must be available for the routes and config because sometimes the env
-# variables are used in routes (e.g. with Livewire).
+# variables are used in routes (e.g. with Livewire). Also it must not be removed because
+# Sometimes the config cache is cleared to enable a dynamic config (e.g. for Laravel Pulse).
 COPY .env /var/www/.env
 RUN php /var/www/artisan route:cache
 RUN php /var/www/artisan config:cache
-RUN rm /var/www/.env


### PR DESCRIPTION
This disabled a Laravel Pulse setup because it needed a dynamic config to resolve the current hostname. Without the .env file it could not generate the new config properly.